### PR TITLE
Add simple Curried extension

### DIFF
--- a/src/Aretek.Functional.Tests/Currying/CurryTests.cs
+++ b/src/Aretek.Functional.Tests/Currying/CurryTests.cs
@@ -1,0 +1,20 @@
+﻿using Aretek.Functional.Currying;
+
+namespace Aretek.Functional.Tests.Currying;
+
+public class CurryTests
+{
+    [Fact(DisplayName = "Curried should apply arguments")]
+    public void Curried_Should_Apply_Arguments()
+    {
+        var func = (int num1, int num2) => num1 + num2;
+
+        var curried = func.Curried();
+
+        var c1 = curried(1);
+        var c2 = curried(2);
+
+        c1(5).Should().Be(6);
+        c2(8).Should().Be(10);
+    }
+}

--- a/src/Aretek.Functional/Currying/CurryExtensions.cs
+++ b/src/Aretek.Functional/Currying/CurryExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Aretek.Functional.Currying;
+
+public static class CurryExtensions
+{
+    /// <summary>
+    /// Turns a regular function into a curried function
+    /// </summary>
+    /// <param name="func">The function that will be curried</param>
+    /// <typeparam name="T1">First argument type</typeparam>
+    /// <typeparam name="T2">Second argument type</typeparam>
+    /// <typeparam name="TResult">Result type</typeparam>
+    /// <returns>The curried function</returns>
+    public static Func<T1, Func<T2, TResult>> Curried<T1, T2, TResult>(
+        this Func<T1, T2, TResult> func
+    ) => t1 => t2 => func(t1, t2);
+}


### PR DESCRIPTION
Added a simple version of the Curried function. This will turn a function (with 2 parameters) into a curried version of it. 