### PR TITLE
Move Curried(), Pipe() and Apply() to Aretek.Functional namespace

### DIFF
--- a/src/Aretek.Functional.Tests/Currying/CurryTests.cs
+++ b/src/Aretek.Functional.Tests/Currying/CurryTests.cs
@@ -1,6 +1,4 @@
-﻿using Aretek.Functional.Currying;
-
-namespace Aretek.Functional.Tests.Currying;
+﻿namespace Aretek.Functional.Tests.Currying;
 
 public class CurryTests
 {

--- a/src/Aretek.Functional.Tests/PartialApplication/ApplyTests.cs
+++ b/src/Aretek.Functional.Tests/PartialApplication/ApplyTests.cs
@@ -1,6 +1,4 @@
-﻿using Aretek.Functional.PartialApplication;
-
-namespace Aretek.Functional.Tests.PartialApplication;
+﻿namespace Aretek.Functional.Tests.PartialApplication;
 
 public class ApplyTests
 {

--- a/src/Aretek.Functional.Tests/Piping/PipeTests.cs
+++ b/src/Aretek.Functional.Tests/Piping/PipeTests.cs
@@ -1,6 +1,4 @@
-﻿using Aretek.Functional.Piping;
-
-namespace Aretek.Functional.Tests.Piping;
+﻿namespace Aretek.Functional.Tests.Piping;
 
 public class PipeTests
 {

--- a/src/Aretek.Functional/ApplyExtensions.cs
+++ b/src/Aretek.Functional/ApplyExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Aretek.Functional.PartialApplication;
+﻿namespace Aretek.Functional;
 
 public static class ApplyExtensions
 {

--- a/src/Aretek.Functional/CurryExtensions.cs
+++ b/src/Aretek.Functional/CurryExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Aretek.Functional.Currying;
+﻿namespace Aretek.Functional;
 
 public static class CurryExtensions
 {

--- a/src/Aretek.Functional/PipeExtensions.cs
+++ b/src/Aretek.Functional/PipeExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Aretek.Functional.Piping;
+﻿namespace Aretek.Functional;
 
 public static class PipeExtensions
 {


### PR DESCRIPTION
I think it is not necessary to have each of these functionalities in their own namespace, so I moved them to the root namespace. Should make it a bit more developer friendly